### PR TITLE
Fix for confusing ordering of form elements and inaccessible form fields

### DIFF
--- a/responsive_1/subtemplates/posting.inc.tpl
+++ b/responsive_1/subtemplates/posting.inc.tpl
@@ -85,12 +85,12 @@
 
 <p>
 <label for="name">{#name_marking#}</label>
-<input id="name" type="text" size="40" name="{$fld_user_name}" value="{if $name}{$name}{/if}" maxlength="{$settings.username_maxlength}"  tabindex="1" />
+<input id="name" type="text" size="40" name="{$fld_user_name}" value="{if $name}{$name}{/if}" maxlength="{$settings.username_maxlength}" />
 </p>
 
 <p>
 <label for="email">{#email_marking#} <span class="xsmall">{#optional_email#}</span></label>
-<input id="email" type="text" size="40" name="{$fld_user_email}" value="{if $email}{$email}{/if}" maxlength="{$settings.email_maxlength}" tabindex="2" />
+<input id="email" type="text" size="40" name="{$fld_user_email}" value="{if $email}{$email}{/if}" maxlength="{$settings.email_maxlength}" />
 </p>
 
 <p class="hp">
@@ -100,7 +100,7 @@
 
 <p>
 <label for="hp">{#hp_marking#} <span class="xsmall">{#optional#}</span></label>
-<input id="hp" type="text" size="40" name="{$fld_hp}" value="{if $hp}{$hp}{/if}" maxlength="{$settings.hp_maxlength}" tabindex="3" />
+<input id="hp" type="text" size="40" name="{$fld_hp}" value="{if $hp}{$hp}{/if}" maxlength="{$settings.hp_maxlength}" />
 </p>
 
 <p class="hp">
@@ -110,7 +110,7 @@
 
 <p>
 <label for="location">{#location_marking#} <span class="xsmall">{#optional#}</span></label>
-<input id="location" type="text" size="40" name="{$fld_location}" value="{if $location}{$location}{/if}" maxlength="{$settings.location_maxlength}" tabindex="4" />
+<input id="location" type="text" size="40" name="{$fld_location}" value="{if $location}{$location}{/if}" maxlength="{$settings.location_maxlength}" />
 </p>
 
 {if $settings.remember_userdata == 1 && $posting_mode==0 && !$user}
@@ -125,7 +125,7 @@
 <fieldset>
 {if $categories}
 <p><label for="p_category">{#category_marking#}</label>
-<select id="p_category" size="1" name="p_category" tabindex="5"{if $posting_mode==0 && $id>0 || $posting_mode==1 && $pid>0} disabled="disabled"{/if}>
+<select id="p_category" size="1" name="p_category" {if $posting_mode==0 && $id>0 || $posting_mode==1 && $pid>0} disabled="disabled"{/if}>
 {foreach key=key item=val from=$categories}
 {if $key!=0}<option value="{$key}"{if $key==$p_category} selected="selected"{/if}>{$val}</option>{/if}
 {/foreach}
@@ -136,13 +136,13 @@
 {/if}
 
 <p><label for="subject">{#subject_marking#}</label>
-<input id="subject" type="text" size="50" name="{$fld_subject}" value="{if $subject}{$subject}{/if}" maxlength="{$settings.subject_maxlength}" tabindex="6" />
+<input id="subject" type="text" size="50" name="{$fld_subject}" value="{if $subject}{$subject}{/if}" maxlength="{$settings.subject_maxlength}" />
 </p>
 
 {if $settings.tags > 0 && ( ($settings.tags == 1 && ($admin || $mod)) || ($settings.tags == 2 && ($user_type === 0 || $admin || $mod)) || $settings.tags > 2 )}
 <p>
 <label for="tags">{#tags_marking#} <span class="xsmall">{#tags_note#}</span></label>
-<input id="tags" type="text" size="50" name="tags" value="{$tags|default:""}" maxlength="253" tabindex="-1" />
+<input id="tags" type="text" size="50" name="tags" value="{$tags|default:""}" maxlength="253" />
 </p>
 {/if}
 </fieldset>
@@ -232,7 +232,7 @@ JavaScript isn't available.
 {/if}
 
 </div>
-<textarea id="text" cols="80" rows="21" name="text" tabindex="7">{if $text}{$text}{/if}</textarea>
+<textarea id="text" cols="80" rows="21" name="text" >{if $text}{$text}{/if}</textarea>
 </fieldset>
 
 {if $signature || $provide_email_notification || $provide_sticky || $terms_of_use_agreement || $data_privacy_agreement}
@@ -244,11 +244,11 @@ JavaScript isn't available.
 {/if}
 {if $terms_of_use_agreement}
 {assign var=terms_of_use_url value=$settings.terms_of_use_url}
- <li><input id="terms_of_use_agree" tabindex="8" type="checkbox" name="terms_of_use_agree" value="1"{if $terms_of_use_agree && $terms_of_use_agree==1} checked="checked"{/if} class="small-input" /><label for="terms_of_use_agree"><span class="icon"></span><span>{if $terms_of_use_url}{#terms_of_use_agreement#|replace:"[[":"<a id=\"terms_of_use\" href=\"$terms_of_use_url\">"|replace:"]]":"</a>"}{else}{#terms_of_use_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></li>
+ <li><input id="terms_of_use_agree" type="checkbox" name="terms_of_use_agree" value="1"{if $terms_of_use_agree && $terms_of_use_agree==1} checked="checked"{/if} class="small-input" /><label for="terms_of_use_agree"><span class="icon"></span><span>{if $terms_of_use_url}{#terms_of_use_agreement#|replace:"[[":"<a id=\"terms_of_use\" href=\"$terms_of_use_url\">"|replace:"]]":"</a>"}{else}{#terms_of_use_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></li>
 {/if}
 {if $data_privacy_agreement}
 {assign var=data_privacy_statement_url value=$settings.data_privacy_statement_url}
- <li><input id="data_privacy_statement_agree" tabindex="9" type="checkbox" name="data_privacy_statement_agree" value="1"{if $data_privacy_statement_agree && $data_privacy_statement_agree==1} checked="checked"{/if} /><label for="data_privacy_statement_agree"><span class="icon"></span><span>{if $data_privacy_statement_url}{#data_privacy_agreement#|replace:"[[":"<a id=\"data_privacy_statement\" href=\"$data_privacy_statement_url\">"|replace:"]]":"</a>"}{else}{#data_privacy_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></li>
+ <li><input id="data_privacy_statement_agree" type="checkbox" name="data_privacy_statement_agree" value="1"{if $data_privacy_statement_agree && $data_privacy_statement_agree==1} checked="checked"{/if} /><label for="data_privacy_statement_agree"><span class="icon"></span><span>{if $data_privacy_statement_url}{#data_privacy_agreement#|replace:"[[":"<a id=\"data_privacy_statement\" href=\"$data_privacy_statement_url\">"|replace:"]]":"</a>"}{else}{#data_privacy_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></li>
 {/if}
 </ul>
 
@@ -279,16 +279,16 @@ JavaScript isn't available.
 {if $captcha.type==2}
 <p><img class="captcha" src="modules/captcha/captcha_image.php?{$session.name}={$session.id}" alt="{#captcha_image_alt#}" width="180" height="40" /><br />
 <label for="captcha_code">{#captcha_expl_image#}</label><br />
-<input id="captcha_code" type="text" name="captcha_code" value="" size="10" tabindex="10" /></p>
+<input id="captcha_code" type="text" name="captcha_code" value="" size="10" /></p>
 {else}
-<p><label for="captcha_code">{#captcha_expl_math#} {$captcha.number_1} + {$captcha.number_2} = </label><input id="captcha_code" type="text" name="captcha_code" value="" size="5" maxlength="5" tabindex="9" /></p>
+<p><label for="captcha_code">{#captcha_expl_math#} {$captcha.number_1} + {$captcha.number_2} = </label><input id="captcha_code" type="text" name="captcha_code" value="" size="5" maxlength="5" /></p>
 {/if}
 </fieldset>
 {/if}
 
 <p>
- <button name="save_entry" value="{#message_submit_button#}" tabindex="12">{#message_submit_button#}</button>
- <button name="preview" value="{#message_preview_button#}" tabindex="11">{#message_preview_button#}</button>
+ <button name="save_entry" value="{#message_submit_button#}">{#message_submit_button#}</button>
+ <button name="preview" value="{#message_preview_button#}">{#message_preview_button#}</button>
 </p>
 </div>
 </form>

--- a/responsive_1/subtemplates/register.inc.tpl
+++ b/responsive_1/subtemplates/register.inc.tpl
@@ -19,36 +19,36 @@
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
 {if $captcha}<input type="hidden" name="{$captcha.session_name}" value="{$captcha.session_id}" />{/if}
 <p><label for="new_user_name" class="main">{#register_username#}</label><br />
-<input id="new_user_name" class="login" type="text" size="30" name="{$fld_user_name}" value="{$new_user_name|default:''}" maxlength="{$settings.username_maxlength}" tabindex="1" /></p>
+<input id="new_user_name" class="login" type="text" size="30" name="{$fld_user_name}" value="{$new_user_name|default:''}" maxlength="{$settings.username_maxlength}" /></p>
 <p><label for="reg_pw" class="main">{#register_pw#}</label><br />
-<input id="reg_pw" class="login" type="password" spellcheck="false" autocomplete="off" size="30" name="{$fld_pword}" maxlength="255" tabindex="3" /></p>
+<input id="reg_pw" class="login" type="password" spellcheck="false" autocomplete="off" size="30" name="{$fld_pword}" maxlength="255" /></p>
 <p class="hp"><label for="phone" class="main">{#register_honeypot_field#}</label><br />
 <input id="phone" class="login" type="text" size="30" name="{$fld_phone}" value="{$honey_pot_phone|default:''}" maxlength="35" tabindex="-1" /></p>
 <p><label for="new_user_email" class="main">{#register_user_email#}</label><br />
-<input id="new_user_email" class="login" type="email" size="30" name="{$fld_user_email}" value="{$new_user_email|default:''}" maxlength="{$settings.email_maxlength}" tabindex="2" /></p>
+<input id="new_user_email" class="login" type="email" size="30" name="{$fld_user_email}" value="{$new_user_email|default:''}" maxlength="{$settings.email_maxlength}" /></p>
 <p class="hp"><label for="repeat_email" class="main">{#register_honeypot_field#}</label><br />
 <input id="repeat_email" class="login" type="text" size="30" name="{$fld_repeat_email}" value="{$honey_pot_email|default:''}" maxlength="{$settings.email_maxlength}" tabindex="-1" /></p>
 {if $terms_of_use_agreement}
 {assign var=terms_of_use_url value=$settings.terms_of_use_url}
-<p><input tabindex="4" id="terms_of_use_agree" type="checkbox" name="terms_of_use_agree" value="1"{if $terms_of_use_agree && $terms_of_use_agree==1} checked="checked"{/if} class="small-input" />&nbsp;<label for="terms_of_use_agree"><span class="icon"></span><span>{if $terms_of_use_url}{#terms_of_use_agreement#|replace:"[[":"<a id=\"terms_of_use\" href=\"$terms_of_use_url\">"|replace:"]]":"</a>"}{else}{#terms_of_use_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></p>
+<p><input id="terms_of_use_agree" type="checkbox" name="terms_of_use_agree" value="1"{if $terms_of_use_agree && $terms_of_use_agree==1} checked="checked"{/if} class="small-input" />&nbsp;<label for="terms_of_use_agree"><span class="icon"></span><span>{if $terms_of_use_url}{#terms_of_use_agreement#|replace:"[[":"<a id=\"terms_of_use\" href=\"$terms_of_use_url\">"|replace:"]]":"</a>"}{else}{#terms_of_use_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></p>
 {/if}
 {if $data_privacy_agreement}
 {assign var=data_privacy_statement_url value=$settings.data_privacy_statement_url}
-<p><input tabindex="5" id="data_privacy_statement_agree" type="checkbox" name="data_privacy_statement_agree" value="1"{if $data_privacy_statement_agree && $data_privacy_statement_agree==1} checked="checked"{/if} />&nbsp;<label for="data_privacy_statement_agree"><span class="icon"></span><span>{if $data_privacy_statement_url}{#data_privacy_agreement#|replace:"[[":"<a id=\"data_priv_declaration\" href=\"$data_privacy_statement_url\">"|replace:"]]":"</a>"}{else}{#data_privacy_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></p>
+<p><input id="data_privacy_statement_agree" type="checkbox" name="data_privacy_statement_agree" value="1"{if $data_privacy_statement_agree && $data_privacy_statement_agree==1} checked="checked"{/if} />&nbsp;<label for="data_privacy_statement_agree"><span class="icon"></span><span>{if $data_privacy_statement_url}{#data_privacy_agreement#|replace:"[[":"<a id=\"data_priv_declaration\" href=\"$data_privacy_statement_url\">"|replace:"]]":"</a>"}{else}{#data_privacy_agreement#|replace:"[[":""|replace:"]]":""}{/if}</span></label></p>
 {/if}
 {if $captcha}
 {if $captcha.type==2}
 <p><strong>{#captcha_marking#}</strong><br />
 <img class="captcha" src="modules/captcha/captcha_image.php?{$captcha.session_name}={$captcha.session_id}" alt="{#captcha_image_alt_reg#}" width="180" height="40" /><br />
 <label for="captcha_code">{#captcha_expl_image#}</label><br />
-<input id="captcha_code" type="text" name="captcha_code" value="" size="10" tabindex="6" /></p>
+<input id="captcha_code" type="text" name="captcha_code" value="" size="10" /></p>
 {else}
 <p><strong>{#captcha_marking#}</strong><br />
 <label for="captcha_code">{#captcha_expl_math#} {$captcha.number_1} + {$captcha.number_2} = </label><br />
-<input id="captcha_code" type="text" name="captcha_code" value="" size="5" tabindex="7" /></p>
+<input id="captcha_code" type="text" name="captcha_code" value="" size="5" /></p>
 {/if}
 {/if}
-<p><button name="register_submit" value="{#submit_button_ok#}" tabindex="8">{#submit_button_ok#}</button></p>
+<p><button name="register_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button></p>
 </div>
 </form>
 </section>


### PR DESCRIPTION


If elements gets a artificial order with `tabindex`, different from the natural one, that is provided by the order of elements in the source code, *all* elements should be ordered with `tabindex`. This is, because when only a few elements get a tabindex, they will be sorted before all other elements, that have no dedicated tabindex.

In the fixed cases one is tabbing into the middle of the document (into the forms), tabbing to the end of the form and from there back to the head section of the document. This is very confusing. Because of that I removed all `tabindex`-attributes, that does not *exclude* an element from tabbing with the value `-1`.

This fixes #40 and in passing also fixes #39.