### PR TITLE
Make form elements accessible with keyboard

### DIFF
--- a/responsive_1/style.new.css
+++ b/responsive_1/style.new.css
@@ -381,6 +381,7 @@ h1 a:active {
 #edit_avatar > span {
 	text-align: center;
 }
+.radio-select input[type="radio"],
 [type="checkbox"],
 .radio-button-native [type="radio"] {
 	border: 0;
@@ -465,9 +466,6 @@ h1 a:active {
 	background-color: #467;
 	background-image: linear-gradient(#467, #456a79);
 	color: #fff;
-}
-.radio-select input[type="radio"] {
-	display: none;
 }
 .radio-toggle-switch ul {
 	list-style: none;

--- a/responsive_1/style.new.css
+++ b/responsive_1/style.new.css
@@ -383,8 +383,16 @@ h1 a:active {
 }
 [type="checkbox"],
 .radio-button-native [type="radio"] {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	width: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
 	position: absolute;
-	left: -9999px;
+	word-wrap: normal !important;
 }
 [type="checkbox"] + label,
 #postingform [type="checkbox"] + label,


### PR DESCRIPTION
As described in #37 a few form elements are not accessible for keyboard users because of the use of `display: none;`. Hide those elements like the other checkboxes and radio buttons. Additionally replace the outdated code for hiding with a more modern attempt, that has a better accessibility than the old attempt with `{ position: absolute; left: -9999px; }`.

This fixes #37.