### PR TITLE
Make the status of the labels of focussed checkboxes and radio buttons visible

### DIFF
--- a/responsive_1/style.new.css
+++ b/responsive_1/style.new.css
@@ -406,6 +406,12 @@ h1 a:active {
 	align-items: center;
 	font-style: italic;
 }
+/* format the labels of focussed checkboxes and "normal" displayed radio buttons */
+[type="checkbox"]:focus + label,
+.radio-button-native [type="radio"]:focus + label {
+	color: #311;
+	text-decoration: underline dotted 0.2em;
+}
 /* replace checkboxes and "normal" displayed radio buttons with graphics */
 [type="checkbox"] + label .icon,
 .radio-button-native [type="radio"] + label .icon {
@@ -471,6 +477,10 @@ h1 a:active {
 	background-image: linear-gradient(#467, #456a79);
 	color: #fff;
 }
+/* format the labels of focussed radiobuttons, that are displayed as buttons */
+.radio-select [type="radio"]:focus + label {
+	text-decoration: underline dotted 0.2em;
+}
 /* format radio buttons, displayed as toggle switches */
 .radio-toggle-switch ul {
 	list-style: none;
@@ -490,6 +500,10 @@ h1 a:active {
 .radio-toggle-switch input[type="radio"]:not(:checked) ~ label {
 	color: #444;
 	font-style: italic;
+}
+/* format the labels of focussed radiobuttons, that are displayed as toggle switches */
+.radio-toggle-switch [type="radio"]:focus + label {
+	text-decoration: underline dotted 0.2em;
 }
 .radio-toggle-switch input {
 	opacity: 0;

--- a/responsive_1/style.new.css
+++ b/responsive_1/style.new.css
@@ -398,7 +398,6 @@ h1 a:active {
 }
 /* format the labels of checkboxes as well as "normal" displayed radio buttons */
 [type="checkbox"] + label,
-#postingform [type="checkbox"] + label,
 .radio-button-native [type="radio"] + label {
 	padding: 0.125em 0.25em;
 	color: #444;

--- a/responsive_1/style.new.css
+++ b/responsive_1/style.new.css
@@ -381,6 +381,7 @@ h1 a:active {
 #edit_avatar > span {
 	text-align: center;
 }
+/* hide all checkboxes and radio buttons visually */
 .radio-select input[type="radio"],
 [type="checkbox"],
 .radio-button-native [type="radio"] {
@@ -395,6 +396,7 @@ h1 a:active {
 	position: absolute;
 	word-wrap: normal !important;
 }
+/* format the labels of checkboxes as well as "normal" displayed radio buttons */
 [type="checkbox"] + label,
 #postingform [type="checkbox"] + label,
 .radio-button-native [type="radio"] + label {
@@ -404,6 +406,7 @@ h1 a:active {
 	align-items: center;
 	font-style: italic;
 }
+/* replace checkboxes and "normal" displayed radio buttons with graphics */
 [type="checkbox"] + label .icon,
 .radio-button-native [type="radio"] + label .icon {
 	display: inline-block;
@@ -433,6 +436,7 @@ h1 a:active {
 	color: #031;
 	font-style: normal;
 }
+/* format radio button lists, and their labels, that are displayed as buttons */
 .radio-select h3 {
 	margin: 0 0 0.5rem 0;
 }
@@ -467,6 +471,7 @@ h1 a:active {
 	background-image: linear-gradient(#467, #456a79);
 	color: #fff;
 }
+/* format radio buttons, displayed as toggle switches */
 .radio-toggle-switch ul {
 	list-style: none;
 	white-space: nowrap;


### PR DESCRIPTION
OS-native visual implementation of checkboxes and radio buttons in browsers are hidden. They are replaced with graphics, that aim the native elements in a zoomable style or with completely different replacements (in a toggle or button style). A pitfall of these replacements is the lack of accessibility of the labels when stepping through the form elements with the keyboard. While textual inputs or selects gets their focus rings, the hidden form elements don't and their labels are not visually hovered by itself.

Hovering the labels of the focussed checkboxes and radio buttons visually, with a dotted underline below the label text and with a different text colour in some cases, enhances the accessibility of the forms.

This fixes #43.